### PR TITLE
Remove encoder resolution magic number

### DIFF
--- a/els-f280049c/Encoder.cpp
+++ b/els-f280049c/Encoder.cpp
@@ -84,7 +84,7 @@ Uint16 Encoder :: getRPM(void)
             count = _ENCODER_MAX_COUNT - count; // just subtract from max value
         }
 
-        rpm = count * 60 * RPM_CALC_RATE_HZ / 4096;
+        rpm = count * 60 * RPM_CALC_RATE_HZ / ENCODER_RESOLUTION;
 
         previous = current;
         EQep1Regs.QCLR.bit.UTO=1;       // Clear interrupt flag


### PR DESCRIPTION
Commit 9e4f611 made encoder resolution a configurable parameter, however
the original "magic number" was not removed from the Encoder::getRPM
function. This creates a regression bug if the encoder resolution is
configured to anything other than 4096

EDIT: Didn't notice there was an open issue for this. This PR will resolve issue #7 