### PR TITLE
Add support for using different stepper rates for feed and threading.

### DIFF
--- a/els-f280049c/Configuration.h
+++ b/els-f280049c/Configuration.h
@@ -67,6 +67,13 @@
 #define STEPPER_MICROSTEPS 8
 #define STEPPER_RESOLUTION 200
 
+// Separate Settings for feed rates, the normal ones are used for threading.
+// This is useful for lathes that do not use the leadscrew for power feed.
+// Note that the leadscrew setting is still used in the formulas, this is a
+// basic adjustment to scale the threading pulse rate.
+#define STEPPER_MICROSTEPS_FEED STEPPER_MICROSTEPS
+#define STEPPER_RESOLUTION_FEED STEPPER_RESOLUTION 
+
 // Step, direction and enable pins are normally active-high
 // #define INVERT_STEP_PIN true
 // #define INVERT_DIRECTION_PIN true

--- a/els-f280049c/Tables.cpp
+++ b/els-f280049c/Tables.cpp
@@ -82,11 +82,11 @@ const FEED_THREAD inch_thread_table[] =
 //
 
 #if defined(LEADSCREW_TPI)
-#define THOU_IN_NUMERATOR(thou) ((Uint32)thou*LEADSCREW_TPI*STEPPER_RESOLUTION*STEPPER_MICROSTEPS)
+#define THOU_IN_NUMERATOR(thou) ((Uint32)thou*LEADSCREW_TPI*STEPPER_RESOLUTION_FEED*STEPPER_MICROSTEPS_FEED)
 #define THOU_IN_DENOMINATOR(thou) ((Uint32)ENCODER_RESOLUTION*1000)
 #endif
 #if defined(LEADSCREW_HMM)
-#define THOU_IN_NUMERATOR(thou) ((Uint32)thou*254*STEPPER_RESOLUTION*STEPPER_MICROSTEPS)
+#define THOU_IN_NUMERATOR(thou) ((Uint32)thou*254*STEPPER_RESOLUTION_FEED*STEPPER_MICROSTEPS_FEED)
 #define THOU_IN_DENOMINATOR(thou) ((Uint32)ENCODER_RESOLUTION*100*LEADSCREW_HMM)
 #endif
 #define THOU_IN_FRACTION(thou) .numerator = THOU_IN_NUMERATOR(thou), .denominator = THOU_IN_DENOMINATOR(thou)
@@ -171,29 +171,39 @@ const FEED_THREAD metric_thread_table[] =
 // Each row in the table defines a standard metric feed, with the display data,
 // LED indicator states and gear ratio fraction to use.
 //
+#if defined(LEADSCREW_TPI)
+#define HMM_NUMERATOR_FEED(hmm) ((Uint32)hmm*10*LEADSCREW_TPI*STEPPER_RESOLUTION_FEED*STEPPER_MICROSTEPS_FEED)
+#define HMM_DENOMINATOR_FEED(hmm) ((Uint32)ENCODER_RESOLUTION*254*100)
+#endif
+#if defined(LEADSCREW_HMM)
+#define HMM_NUMERATOR_FEED(hmm) ((Uint32)hmm*STEPPER_RESOLUTION_FEED*STEPPER_MICROSTEPS_FEED)
+#define HMM_DENOMINATOR_FEED(hmm) ((Uint32)ENCODER_RESOLUTION*LEADSCREW_HMM)
+#endif
+#define HMM_FRACTION_FEED(hmm) .numerator = HMM_NUMERATOR_FEED(hmm), .denominator = HMM_DENOMINATOR_FEED(hmm)
+
 const FEED_THREAD metric_feed_table[] =
 {
- { .display = {BLANK, POINT,       ZERO,  TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION(2) },
- { .display = {BLANK, POINT,       ZERO,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(5) },
- { .display = {BLANK, POINT,       ZERO,  SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION(7) },
- { .display = {BLANK, POINT,       ONE,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(10) },
- { .display = {BLANK, POINT,       ONE,   TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION(12) },
- { .display = {BLANK, POINT,       ONE,   FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(15) },
- { .display = {BLANK, POINT,       ONE,   SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION(17) },
- { .display = {BLANK, POINT,       TWO,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(20) },
- { .display = {BLANK, POINT,       TWO,   TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION(22) },
- { .display = {BLANK, POINT,       TWO,   FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(25) },
- { .display = {BLANK, POINT,       TWO,   SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION(27) },
- { .display = {BLANK, POINT,       THREE, ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(30) },
- { .display = {BLANK, POINT,       THREE, FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(35) },
- { .display = {BLANK, POINT,       FOUR,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(40) },
- { .display = {BLANK, POINT,       FOUR,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(45) },
- { .display = {BLANK, POINT,       FIVE,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(50) },
- { .display = {BLANK, POINT,       FIVE,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(55) },
- { .display = {BLANK, POINT,       SIX,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(60) },
- { .display = {BLANK, POINT,       SEVEN, ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(70) },
- { .display = {BLANK, POINT,       EIGHT, FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION(85) },
- { .display = {BLANK, ONE | POINT, ZERO,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION(100) },
+ { .display = {BLANK, POINT,       ZERO,  TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(2) },
+ { .display = {BLANK, POINT,       ZERO,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(5) },
+ { .display = {BLANK, POINT,       ZERO,  SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(7) },
+ { .display = {BLANK, POINT,       ONE,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(10) },
+ { .display = {BLANK, POINT,       ONE,   TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(12) },
+ { .display = {BLANK, POINT,       ONE,   FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(15) },
+ { .display = {BLANK, POINT,       ONE,   SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(17) },
+ { .display = {BLANK, POINT,       TWO,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(20) },
+ { .display = {BLANK, POINT,       TWO,   TWO},   .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(22) },
+ { .display = {BLANK, POINT,       TWO,   FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(25) },
+ { .display = {BLANK, POINT,       TWO,   SEVEN}, .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(27) },
+ { .display = {BLANK, POINT,       THREE, ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(30) },
+ { .display = {BLANK, POINT,       THREE, FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(35) },
+ { .display = {BLANK, POINT,       FOUR,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(40) },
+ { .display = {BLANK, POINT,       FOUR,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(45) },
+ { .display = {BLANK, POINT,       FIVE,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(50) },
+ { .display = {BLANK, POINT,       FIVE,  FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(55) },
+ { .display = {BLANK, POINT,       SIX,   ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(60) },
+ { .display = {BLANK, POINT,       SEVEN, ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(70) },
+ { .display = {BLANK, POINT,       EIGHT, FIVE},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(85) },
+ { .display = {BLANK, ONE | POINT, ZERO,  ZERO},  .leds = LED_FEED | LED_MM, HMM_FRACTION_FEED(100) },
 };
 
 


### PR DESCRIPTION
My lathe does not use the leadscrew for power feed. This change allows me to use a different stepper setup for the power feed without interfering with the existing setup. The default settings included just mirror the threading rates, so it will work as it always did. 

In my case, there is a different ratio involved. So I use this setting to compensate so that the carriage moves the indicated amount per rev. 

#define STEPPER_RESOLUTION_FEED STEPPER_RESOLUTION * 1.66

I tested it on my PM1127 in imperial and metric modes, both for feed and thread. Everything moves as I would expect. 