### PR TITLE
Feature: RPM Display "Stabilization"

### DIFF
--- a/els-f280049c/Configuration.h
+++ b/els-f280049c/Configuration.h
@@ -126,6 +126,21 @@
 #define HARDWARE_VERSION 2
 
 
+
+
+//================================================================================
+//                                DISPLAY
+//
+// Define display parameters.
+//================================================================================
+
+// RPM Sample Size - Used to stabilize RPM display by averaging out over
+// sample size, and oly updating display after sample size has been reached.
+#define RPM_SAMPLE_SIZE 50
+
+
+
+
 //================================================================================
 //                               CPU / TIMING
 //

--- a/els-f280049c/Configuration.h
+++ b/els-f280049c/Configuration.h
@@ -136,7 +136,7 @@
 
 // RPM Sample Size - Used to stabilize RPM display by averaging out over
 // sample size, and oly updating display after sample size has been reached.
-#define RPM_SAMPLE_SIZE 50
+#define RPM_DISPLAY_SAMPLE_SIZE 50
 
 
 

--- a/els-f280049c/ControlPanel.cpp
+++ b/els-f280049c/ControlPanel.cpp
@@ -133,7 +133,7 @@ Uint16 ControlPanel :: lcd_char(Uint16 x)
 
 void ControlPanel :: resetRPMSamples()
 {
-    for (int i = 0; i < RPM_SAMPLE_SIZE; i++)
+    for (int i = 0; i < RPM_DISPLAY_SAMPLE_SIZE; i++)
     {
         this->rpm_samples[i] = -1u;
     }
@@ -189,7 +189,7 @@ Uint16 ControlPanel :: addRPMSample(Uint16 rpmSample)
 
     int sampleCount = 0;
     unsigned long rpmSum = rpmSample;
-    for (int i = 0; i < RPM_SAMPLE_SIZE; i++)
+    for (int i = 0; i < RPM_DISPLAY_SAMPLE_SIZE; i++)
     {
         sampleCount++;
         if (this->rpm_samples[i] == -1u)
@@ -200,7 +200,7 @@ Uint16 ControlPanel :: addRPMSample(Uint16 rpmSample)
         rpmSum += this->rpm_samples[i];
     }
 
-    if (sampleCount >= RPM_SAMPLE_SIZE)
+    if (sampleCount >= RPM_DISPLAY_SAMPLE_SIZE)
     {
         this->rpm = rpmSum / sampleCount;
         this->resetRPMSamples();

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -130,7 +130,7 @@ private:
     Uint16 rpm;
 
     // RPM Samples
-    Uint16 rpm_samples[RPM_SAMPLE_SIZE];
+    Uint16 rpm_samples[RPM_DISPLAY_SAMPLE_SIZE];
 
     // Current displayed setting value, 4 digits
     const Uint16 *value;

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -27,6 +27,7 @@
 #ifndef __CONTROL_PANEL_H
 #define __CONTROL_PANEL_H
 
+#include "Configuration.h"
 #include "F28x_Project.h"
 #include "SPIBus.h"
 
@@ -128,6 +129,9 @@ private:
     // Current RPM value; 4 decimal digits
     Uint16 rpm;
 
+    // RPM Samples
+    Uint16 rpm_samples[RPM_SAMPLE_SIZE];
+
     // Current displayed setting value, 4 digits
     const Uint16 *value;
 
@@ -149,6 +153,7 @@ private:
     // dummy register, for SPI
     Uint16 dummy;
 
+    void resetRPMSamples(void);
     void decomposeRPM(void);
     void decomposeValue(void);
     KEY_REG readKeys(void);
@@ -159,6 +164,7 @@ private:
     Uint16 reverse_byte(Uint16 x);
     void initSpi();
     void configureSpiBus(void);
+    Uint16 addRPMSample(Uint16 rpmSample);
 
 public:
     ControlPanel(SPIBus *spiBus);
@@ -191,7 +197,7 @@ public:
 
 inline void ControlPanel :: setRPM(Uint16 rpm)
 {
-    this->rpm = rpm;
+    this->rpm = this->addRPMSample(rpm);
 }
 
 inline void ControlPanel :: setValue(const Uint16 *value)


### PR DESCRIPTION
Updated so that RPM display gets calculated based on a configurable sample size (50 seemed to produce good results) and the average of all sample values is used. This reduces the jumping around of RPM values on the display.