### PR TITLE
Feature: PWR Button Support

### DIFF
--- a/els-f280049c/Configuration.h
+++ b/els-f280049c/Configuration.h
@@ -27,8 +27,15 @@
 #ifndef __CONFIGURATION_H
 #define __CONFIGURATION_H
 
-
-
+//================================================================================
+//                                  GENERAL
+//
+// Define general preferences...
+//
+// PWR_OFF_SHOW_RPM: true to show RPM readout in "power off" mode, false to
+//                   prevent RPM readout in "power off" mode.
+//================================================================================
+#define PWR_OFF_SHOW_RPM true
 
 //================================================================================
 //                                  LEADSCREW

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -118,6 +118,13 @@ typedef union KEY_REG
     struct KEY_BITS bit;
 } KEY_REG;
 
+const LED_REG POWER_OFF_LEDS =
+{
+   .all = 0
+};
+
+const Uint16 POWER_OFF_MESSAGE[4] = { BLANK, LETTER_O, LETTER_F, LETTER_F };
+
 
 class ControlPanel
 {
@@ -149,6 +156,8 @@ private:
     // dummy register, for SPI
     Uint16 dummy;
 
+    bool isElsEnabled;
+
     void decomposeRPM(void);
     void decomposeValue(void);
     KEY_REG readKeys(void);
@@ -169,6 +178,8 @@ public:
     // poll the keys and return a mask
     KEY_REG getKeys(void);
 
+    void setElsEnabled(bool isEnabled);
+
     // set the RPM value to display
     void setRPM(Uint16 rpm);
 
@@ -188,6 +199,10 @@ public:
     void refresh(void);
 };
 
+inline void ControlPanel :: setElsEnabled(bool isEnabled)
+{
+    this->isElsEnabled = isEnabled;
+}
 
 inline void ControlPanel :: setRPM(Uint16 rpm)
 {

--- a/els-f280049c/Core.h
+++ b/els-f280049c/Core.h
@@ -61,6 +61,8 @@ public:
     void setReverse(bool reverse);
     Uint16 getRPM(void);
     bool isAlarm();
+    void setEnabled(bool enabled);
+    bool isEnabled(void);
 
     void ISR( void );
 };
@@ -82,6 +84,16 @@ inline Uint16 Core :: getRPM(void)
 inline bool Core :: isAlarm()
 {
     return this->stepperDrive->isAlarm();
+}
+
+inline void Core :: setEnabled(bool enabled)
+{
+    this->stepperDrive->setEnabled(enabled);
+}
+
+inline bool Core :: isEnabled(void)
+{
+    return this->stepperDrive->isEnabled();
 }
 
 inline int32 Core :: feedRatio(Uint32 count)

--- a/els-f280049c/StepperDrive.h
+++ b/els-f280049c/StepperDrive.h
@@ -59,9 +59,11 @@
 #ifdef INVERT_ENABLE_PIN
 #define GPIO_SET_ENABLE GPIO_CLEAR(ENABLE_PIN)
 #define GPIO_CLEAR_ENABLE GPIO_SET(ENABLE_PIN)
+#define GPIO_GET_ENABLE (GPIO_GET(ENABLE_PIN) == 0)
 #else
 #define GPIO_SET_ENABLE GPIO_SET(ENABLE_PIN)
 #define GPIO_CLEAR_ENABLE GPIO_CLEAR(ENABLE_PIN)
+#define GPIO_GET_ENABLE (GPIO_GET(ENABLE_PIN) != 0)
 #endif
 
 #ifdef INVERT_ALARM_PIN
@@ -101,6 +103,9 @@ public:
 
     bool isAlarm();
 
+    bool isEnabled(void);
+    void setEnabled(bool enabled);
+
     void ISR(void);
 };
 
@@ -128,6 +133,21 @@ inline bool StepperDrive :: isAlarm()
 #endif
 }
 
+inline void StepperDrive :: setEnabled(bool enabled)
+{
+    if (enabled)
+    {
+        GPIO_SET_ENABLE;
+    } else
+    {
+        GPIO_CLEAR_ENABLE;
+    }
+}
+
+inline bool StepperDrive :: isEnabled(void)
+{
+    return GPIO_GET_ENABLE;
+}
 
 inline void StepperDrive :: ISR(void)
 {

--- a/els-f280049c/UserInterface.cpp
+++ b/els-f280049c/UserInterface.cpp
@@ -134,6 +134,7 @@ void UserInterface :: loop( void )
     const FEED_THREAD *newFeed = NULL;
 
 
+    // only show messages if ELS is "On"
     if (this->core->isEnabled())
     {
         // display an override message, if there is one
@@ -164,7 +165,7 @@ void UserInterface :: loop( void )
         this->controlPanel->setElsEnabled(powerState);
     }
 
-    // only respond to other button events if ELS is enabled
+    // only respond to other button events if ELS is "On"
     if (this->core->isEnabled())
     {
         if( keys.bit.IN_MM )

--- a/els-f280049c/UserInterface.h
+++ b/els-f280049c/UserInterface.h
@@ -58,7 +58,6 @@ private:
 
     const FEED_THREAD *loadFeedTable();
     LED_REG calculateLEDs(const FEED_THREAD *selectedFeed);
-    LED_REG getPoweredOffLEDs(void);
     void setMessage(const MESSAGE *message);
     void overrideMessage( void );
 

--- a/els-f280049c/UserInterface.h
+++ b/els-f280049c/UserInterface.h
@@ -58,6 +58,7 @@ private:
 
     const FEED_THREAD *loadFeedTable();
     LED_REG calculateLEDs(const FEED_THREAD *selectedFeed);
+    LED_REG getPoweredOffLEDs(void);
     void setMessage(const MESSAGE *message);
     void overrideMessage( void );
 


### PR DESCRIPTION
Added support for functional power button that disables the lead screw motor/driver. When PWR button is pressed, all LEDs will go off and display will read "OFF", when PWR button is pressed again the LEDs are re-enabled to proper states, and the display briefly shows "ON" before returning to normal state. Note: the current setting are not altered by toggling of the "power" state, so feed/direction settings that were in place before power off will remain when PWR is toggled back on.