### PR TITLE
Auto

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>electronic-leadscrew</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/els-f280049c/ControlPanel.cpp
+++ b/els-f280049c/ControlPanel.cpp
@@ -293,11 +293,42 @@ void ControlPanel :: setMessage( const Uint16 *message )
     this->message = message;
 }
 
-void ControlPanel :: setBrightness( Uint16 brightness )
+void ControlPanel :: increaseBrightness()
 {
+    ++brightness;
+
+    if (brightness == 5) brightness = 8;
+
+    setBrightness(brightness);
+}
+
+void ControlPanel :: decreaseBrightness()
+{
+    --brightness;
+
+    if(brightness == 7) brightness = 4;
+
+    setBrightness(brightness);
+}
+
+void ControlPanel :: setBrightness( Uint16 brightness )
+//  Because of the screwy way the TM1638 controls brightness in steps of 1/16,
+//      2/16, 4/16, 10/16, 11/16, 12/16, 13/16, and 14/16,
+//      there are really only five distinct levels.
+//  Limit brightness value sent to control panel to 1, 2, 3, 4, or 8.
+//      0 = off.
+//      5, 6, and 7 are indistinguishable from 4.
+{
+    if (brightness == 0) brightness = 1;
+
     if( brightness > 8 ) brightness = 8;
 
     this->brightness = brightness;
+}
+
+Uint16 ControlPanel :: getBrightness(void)
+{
+    return this->brightness;
 }
 
 void ControlPanel :: refresh()

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -30,6 +30,16 @@
 #include "F28x_Project.h"
 #include "SPIBus.h"
 
+// Seven segment display segment mapping:
+//
+//  MSb 7 6 5 4 3 2 1 0  x x x x x x x x LSb
+//
+//     7
+//  2     6
+//     1
+//  3     5
+//     4
+//           0
 
 #define ZERO    0b1111110000000000 // 0
 #define ONE     0b0110000000000000 // 1
@@ -44,32 +54,60 @@
 #define POINT   0b0000000100000000 // .
 #define BLANK   0b0000000000000000
 
+// Some lowercase letters have to be the same as the
+//      uppercase letter.
 #define LETTER_A 0b1110111000000000
+#define LETTER_a 0b1111101000000000
 #define LETTER_B 0b0011111000000000
+#define LETTER_b 0b0011111000000000
 #define LETTER_C 0b1001110000000000
+#define LETTER_c 0b0011001000000000
 #define LETTER_D 0b0111101000000000
+#define LETTER_d 0b0111101000000000
 #define LETTER_E 0b1001111000000000
+#define LETTER_e 0b1001111000000000
 #define LETTER_F 0b1000111000000000
+#define LETTER_f 0b1000111000000000
 #define LETTER_G 0b1011110000000000
+#define LETTER_g 0b1011110000000000
 #define LETTER_H 0b0110111000000000
+#define LETTER_h 0b0010111000000000
 #define LETTER_I 0b0000110000000000
+#define LETTER_i 0b0010000000000000
 #define LETTER_J 0b0111100000000000
+#define LETTER_j 0b0111100000000000
 #define LETTER_K 0b1010111000000000
+#define LETTER_k 0b1010111000000000
 #define LETTER_L 0b0001110000000000
+#define LETTER_l 0b0001110000000000
 #define LETTER_M 0b1010100000000000
+#define LETTER_m 0b1010100000000000
 #define LETTER_N 0b1110110000000000
+#define LETTER_n 0b0010101000000000
 #define LETTER_O 0b1111110000000000
+#define LETTER_o 0b0011101000000000
 #define LETTER_P 0b1100111000000000
+#define LETTER_p 0b1100111000000000
 #define LETTER_Q 0b1110011000000000
+#define LETTER_q 0b1110011000000000
 #define LETTER_R 0b1100110000000000
+#define LETTER_r 0b0000101000000000
 #define LETTER_S 0b1011011000000000
+#define LETTER_s 0b1011011000000000
 #define LETTER_T 0b0001111000000000
+#define LETTER_t 0b0001111000000000
 #define LETTER_U 0b0111110000000000
+#define LETTER_u 0b0011100000000000
 #define LETTER_V 0b0111010000000000
+#define LETTER_v 0b0111010000000000
 #define LETTER_W 0b0101010000000000
+#define LETTER_w 0b0101010000000000
 #define LETTER_X 0b0110110000000000
+#define LETTER_x 0b0110110000000000
 #define LETTER_Y 0b0111011000000000
+#define LETTER_y 0b0111011000000000
 #define LETTER_Z 0b1101001000000000
+#define LETTER_z 0b1101001000000000
 
 #define DASH 0b0000001000000000
 
@@ -165,6 +203,7 @@ private:
     void configureSpiBus(void);
     bool isValidKeyState(KEY_REG);
     bool isStable(KEY_REG);
+    void setBrightness(Uint16 x);
 
 public:
     ControlPanel(SPIBus *spiBus);
@@ -187,8 +226,11 @@ public:
     // set a message that overrides the display, 8 characters required
     void setMessage(const Uint16 *message);
 
-    // set a brightness value, 0 (off) to 8 (max)
-    void setBrightness(Uint16 brightness);
+    Uint16 getBrightness(void);
+
+    void increaseBrightness(void);
+
+    void decreaseBrightness(void);
 
     // refresh the hardware display
     void refresh(void);

--- a/els-f280049c/ControlPanel.h
+++ b/els-f280049c/ControlPanel.h
@@ -111,6 +111,28 @@
 
 #define DASH 0b0000001000000000
 
+// button state machine constants
+#define BSM_NO_ACTION 0
+#define BSM_INCREMENT 1
+#define BSM_DECREMENT 2
+
+#define BSM_INITIAL_DELAY 30    // delay before auto slow increment/decrement begins
+#define BSM_SLOW_DELAY 15        // delay between changes in auto slow increment/decrement
+#define BSM_FAST_DELAY 5        // delay between changes in auto fast increment/decrement
+
+#define BSM_INPUT_NEITHER_BUTTON_PRESSED 0
+#define BSM_INPUT_INCREMENT_BUTTON_PRESSED 1
+#define BSM_INPUT_DECREMENT_BUTTON_PRESSED 2
+#define BSM_INPUT_BOTH_BUTTONS_PRESSED 3
+
+#define BSM_STATE_IDLE 0
+#define BSM_STATE_WAIT_FOR_AUTO_SLOW_INCREMENT 1
+#define BSM_STATE_WAIT_FOR_AUTO_SLOW_DECREMENT 2
+#define BSM_STATE_AUTO_SLOW_INCREMENT 3
+#define BSM_STATE_AUTO_SLOW_DECREMENT 4
+#define BSM_STATE_AUTO_FAST_INCREMENT 5
+#define BSM_STATE_AUTO_FAST_DECREMENT 6
+
 #define LED_TPI 1
 #define LED_INCH (1<<1)
 #define LED_MM (1<<2)
@@ -140,6 +162,7 @@ typedef union LED_REG
 
 struct KEY_BITS
 {
+    // MSb POWER, SET, FWD/REV, FEED/THREAD, IN/MM, DOWN, x, UP LSb
     Uint16 UP:1;
     Uint16 reserved1:1;
     Uint16 DOWN:1;
@@ -234,6 +257,8 @@ public:
 
     // refresh the hardware display
     void refresh(void);
+
+    Uint16 buttonStateMachine(bool x, bool y);
 };
 
 

--- a/els-f280049c/Debug.cpp
+++ b/els-f280049c/Debug.cpp
@@ -35,13 +35,25 @@ Debug :: Debug( void )
 
 void Debug :: initHardware( void )
 {
+    // Initialize GPIO
+    // Doesn't work if put after EALLOW
+    InitGpio();
+
     // set up GPIO pins as output for debugging
     EALLOW;
+
     GpioCtrlRegs.GPAMUX1.bit.GPIO2 = 0;
     GpioCtrlRegs.GPADIR.bit.GPIO2 = 1;
     GpioDataRegs.GPACLEAR.bit.GPIO2 = 1;
+
     GpioCtrlRegs.GPAMUX1.bit.GPIO3 = 0;
     GpioCtrlRegs.GPADIR.bit.GPIO3 = 1;
     GpioDataRegs.GPACLEAR.bit.GPIO3 = 1;
+
+    // LED4 on LAUNCHXL (red)
+    GpioCtrlRegs.GPAMUX2.bit.GPIO23 = 0;
+    GpioCtrlRegs.GPADIR.bit.GPIO23 = 1;
+    GpioDataRegs.GPACLEAR.bit.GPIO23 = 1;
+
     EDIS;
 }

--- a/els-f280049c/Debug.h
+++ b/els-f280049c/Debug.h
@@ -31,6 +31,9 @@
 
 class Debug
 {
+private:
+    Uint16 heartbeatCount;
+
 public:
     Debug(void);
     void initHardware(void);
@@ -42,6 +45,8 @@ public:
     // analyzer pin 2
     void begin2( void );
     void end2( void );
+
+    void heartbeat( void );
 };
 
 
@@ -65,5 +70,28 @@ inline void Debug :: end2( void )
     GpioDataRegs.GPACLEAR.bit.GPIO3 = 1;
 }
 
+inline void Debug :: heartbeat( void )
+{
+    ++heartbeatCount;
+
+    if (heartbeatCount > 50)
+    {
+        heartbeatCount = 1;
+    }
+
+    if (heartbeatCount == 15)
+    {
+        // Turn off red LED and turn on green LED
+        GpioDataRegs.GPASET.bit.GPIO23 = 1;
+        GpioDataRegs.GPBCLEAR.bit.GPIO34 = 1;
+    }
+
+    if (heartbeatCount == 1)
+    {
+        // Turn on red LED and turn off green LED
+        GpioDataRegs.GPACLEAR.bit.GPIO23 = 1;
+        GpioDataRegs.GPBSET.bit.GPIO34 = 1;
+    }
+}
 
 #endif // __DEBUG_H

--- a/els-f280049c/UserInterface.cpp
+++ b/els-f280049c/UserInterface.cpp
@@ -25,6 +25,7 @@
 
 
 #include "UserInterface.h"
+#include "ControlPanel.h"
 
 const MESSAGE STARTUP_MESSAGE_2 =
 {
@@ -174,6 +175,7 @@ Uint16 UserInterface :: digitToSevenSegmentPattern(Uint16 digit)
 void UserInterface :: loop( void )
 {
     Uint16 number;
+    Uint16 action;
 
     // read the RPM up front so we can use it to make decisions
     Uint16 currentRpm = core->getRPM();
@@ -280,7 +282,7 @@ void UserInterface :: loop( void )
                     break;
 
                 case UI_STATE_ENCODER_RES:
-                    userInterfaceState = UI_STATE_NORMAL;
+                    userInterfaceState = UI_STATE_CANCEL;
 
                     USER_INTERFACE_STATE.message[0] = LETTER_E | POINT;
                     USER_INTERFACE_STATE.message[1] = LETTER_r;
@@ -295,6 +297,11 @@ void UserInterface :: loop( void )
 
                     setMessage(&USER_INTERFACE_STATE);
                     break;
+
+                case UI_STATE_CANCEL:
+                    userInterfaceState = UI_STATE_NORMAL;
+
+                    this->messageTime = 0;
 
                 default:
                     userInterfaceState = UI_STATE_NORMAL;
@@ -316,31 +323,57 @@ void UserInterface :: loop( void )
             {
             case UI_STATE_NORMAL:
 
-                if( keys.bit.UP )
+//                if( keys.bit.UP )
+//                {
+//                    core->setFeed(feedTable->next());
+//                }
+//                if( keys.bit.DOWN )
+//                {
+//                    core->setFeed(feedTable->previous());
+//                }
+
+                action = controlPanel->buttonStateMachine(keys.bit.UP, keys.bit.DOWN);
+
+                if( action == BSM_INCREMENT )
                 {
                     core->setFeed(feedTable->next());
                 }
-                if( keys.bit.DOWN )
+                if( action == BSM_DECREMENT )
                 {
                     core->setFeed(feedTable->previous());
                 }
-                break;
+            break;
 
             case UI_STATE_ADJ_BRT:
 
-                if( keys.bit.UP )
+                action = controlPanel->buttonStateMachine(keys.bit.UP, keys.bit.DOWN);
+
+                if( action == BSM_INCREMENT )
                 {
                     controlPanel->increaseBrightness();
                     USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
                     setMessage(&USER_INTERFACE_STATE);
                 }
-
-                if( keys.bit.DOWN )
+                if( action == BSM_DECREMENT )
                 {
                     controlPanel->decreaseBrightness();
                     USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
                     setMessage(&USER_INTERFACE_STATE);
                 }
+
+//                if( keys.bit.UP )
+//                {
+//                    controlPanel->increaseBrightness();
+//                   USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
+//                    setMessage(&USER_INTERFACE_STATE);
+//                }
+//
+//                if( keys.bit.DOWN )
+//                {
+//                    controlPanel->decreaseBrightness();
+//                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
+//                    setMessage(&USER_INTERFACE_STATE);
+//                }
 
                 break;
             } // switch

--- a/els-f280049c/UserInterface.cpp
+++ b/els-f280049c/UserInterface.cpp
@@ -39,23 +39,18 @@ const MESSAGE STARTUP_MESSAGE_1 =
  .next = &STARTUP_MESSAGE_2
 };
 
-const MESSAGE SETTINGS_MESSAGE_2 =
+MESSAGE USER_INTERFACE_STATE =
 {
- .message = { LETTER_S, LETTER_E, LETTER_T, LETTER_T, LETTER_I, LETTER_N, LETTER_G, LETTER_S },
- .displayTime = UI_REFRESH_RATE_HZ * .5
-};
-
-const MESSAGE SETTINGS_MESSAGE_1 =
-{
- .message = { BLANK, BLANK, BLANK, LETTER_N, LETTER_O, BLANK, BLANK, BLANK },
- .displayTime = UI_REFRESH_RATE_HZ * .5,
- .next = &SETTINGS_MESSAGE_2
+ .message = { LETTER_S, LETTER_T, LETTER_A, LETTER_T, LETTER_E, BLANK, BLANK, BLANK },
+ .displayTime = UI_REFRESH_RATE_HZ * 2
 };
 
 const Uint16 VALUE_BLANK[4] = { BLANK, BLANK, BLANK, BLANK };
 
 UserInterface :: UserInterface(ControlPanel *controlPanel, Core *core, FeedTableFactory *feedTableFactory)
 {
+    userInterfaceState = UI_STATE_NORMAL;
+
     this->controlPanel = controlPanel;
     this->core = core;
     this->feedTableFactory = feedTableFactory;
@@ -110,24 +105,76 @@ void UserInterface :: setMessage(const MESSAGE *message)
 
 void UserInterface :: overrideMessage( void )
 {
+    // see if an override message is pending
     if( this->message != NULL )
     {
-        if( this->messageTime > 0 ) {
+        // message pending
+        // see if message display has timed out
+        if( this->messageTime > 0 )
+        {
+            // not timed out
+            // adjust display time
             this->messageTime--;
+
+            // queue the message to be displayed
             controlPanel->setMessage(this->message->message);
         }
-        else {
+        else
+        {
+            // timed out
+            // reset user interface state to normal
+            userInterfaceState = UI_STATE_NORMAL;
+
+            // see if there's another message
             this->message = this->message->next;
             if( this->message == NULL )
+            {
+                // no more messages
                 controlPanel->setMessage(NULL);
+            }
             else
+            {
+                // more messages
+                // set to display next message
                 this->messageTime = this->message->displayTime;
+            }
         }
+    } // message pending
+}
+
+Uint16 UserInterface :: digitToSevenSegmentPattern(Uint16 digit)
+{
+    switch (digit)
+    {
+    case 0:
+        return ZERO;
+    case 1:
+        return ONE;
+    case 2:
+        return TWO;
+    case 3:
+        return THREE;
+    case 4:
+        return FOUR;
+    case 5:
+        return FIVE;
+    case 6:
+        return SIX;
+    case 7:
+        return SEVEN;
+    case 8:
+        return EIGHT;
+    case 9:
+        return NINE;
+    default:
+        return DASH;
     }
 }
 
 void UserInterface :: loop( void )
 {
+    Uint16 number;
+
     // read the RPM up front so we can use it to make decisions
     Uint16 currentRpm = core->getRPM();
 
@@ -141,12 +188,16 @@ void UserInterface :: loop( void )
     if( currentRpm == 0 )
     {
         // these keys should only be sensitive when the machine is stopped
-        if( keys.bit.POWER ) {
+        if( keys.bit.POWER )
+        {
             this->core->setPowerOn(!this->core->isPowerOn());
+
+            userInterfaceState = UI_STATE_NORMAL;
         }
 
         // these should only work when the power is on
-        if( this->core->isPowerOn() ) {
+        if( this->core->isPowerOn() )
+        {
             if( keys.bit.IN_MM )
             {
                 this->metric = ! this->metric;
@@ -164,10 +215,93 @@ void UserInterface :: loop( void )
             }
             if( keys.bit.SET )
             {
-                setMessage(&SETTINGS_MESSAGE_1);
-            }
-        }
-    }
+                switch (userInterfaceState)
+                {
+                case UI_STATE_NORMAL:
+                    userInterfaceState = UI_STATE_ADJ_BRT;
+
+                    USER_INTERFACE_STATE.message[0] = LETTER_B;
+                    USER_INTERFACE_STATE.message[1] = LETTER_r;
+                    USER_INTERFACE_STATE.message[2] = LETTER_t;
+                    USER_INTERFACE_STATE.message[3] = BLANK;
+                    USER_INTERFACE_STATE.message[4] = BLANK;
+                    USER_INTERFACE_STATE.message[5] = BLANK;
+                    USER_INTERFACE_STATE.message[6] = BLANK;
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
+
+                    setMessage(&USER_INTERFACE_STATE);
+                break;
+
+                case UI_STATE_ADJ_BRT:
+                    userInterfaceState = UI_STATE_uSTPS;
+
+                    USER_INTERFACE_STATE.message[0] = LETTER_L;
+                    USER_INTERFACE_STATE.message[1] = LETTER_E;
+                    USER_INTERFACE_STATE.message[2] = LETTER_A;
+                    USER_INTERFACE_STATE.message[3] = LETTER_D;
+                    USER_INTERFACE_STATE.message[4] = BLANK;
+                    USER_INTERFACE_STATE.message[5] = BLANK;
+                    USER_INTERFACE_STATE.message[6] = digitToSevenSegmentPattern(LEADSCREW_TPI / 10);
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(LEADSCREW_TPI % 10);
+
+                    setMessage(&USER_INTERFACE_STATE);
+                    break;
+
+                case UI_STATE_uSTPS:
+                    userInterfaceState = UI_STATE_STEPPER_RES;
+
+                    USER_INTERFACE_STATE.message[0] = LETTER_u;
+                    USER_INTERFACE_STATE.message[1] = LETTER_S;
+                    USER_INTERFACE_STATE.message[2] = LETTER_T;
+                    USER_INTERFACE_STATE.message[3] = LETTER_P;
+                    USER_INTERFACE_STATE.message[4] = LETTER_S;
+                    USER_INTERFACE_STATE.message[5] = BLANK;
+                    USER_INTERFACE_STATE.message[6] = BLANK;
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(STEPPER_MICROSTEPS);
+
+                    setMessage(&USER_INTERFACE_STATE);
+                    break;
+
+                case UI_STATE_STEPPER_RES:
+                    userInterfaceState = UI_STATE_ENCODER_RES;
+
+                    USER_INTERFACE_STATE.message[0] = LETTER_S | POINT;
+                    USER_INTERFACE_STATE.message[1] = LETTER_r;
+                    USER_INTERFACE_STATE.message[2] = LETTER_E;
+                    USER_INTERFACE_STATE.message[3] = LETTER_S;
+                    number = STEPPER_RESOLUTION;
+                    // note the next four are in reverse order
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern( number % 10 );
+                    USER_INTERFACE_STATE.message[6] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+                    USER_INTERFACE_STATE.message[5] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+                    USER_INTERFACE_STATE.message[4] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+
+                    setMessage(&USER_INTERFACE_STATE);
+                    break;
+
+                case UI_STATE_ENCODER_RES:
+                    userInterfaceState = UI_STATE_NORMAL;
+
+                    USER_INTERFACE_STATE.message[0] = LETTER_E | POINT;
+                    USER_INTERFACE_STATE.message[1] = LETTER_r;
+                    USER_INTERFACE_STATE.message[2] = LETTER_E;
+                    USER_INTERFACE_STATE.message[3] = LETTER_S;
+                    number = ENCODER_RESOLUTION;
+                    // note the next four are in reverse order
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern( number % 10 );
+                    USER_INTERFACE_STATE.message[6] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+                    USER_INTERFACE_STATE.message[5] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+                    USER_INTERFACE_STATE.message[4] = digitToSevenSegmentPattern( (number = number / 10) % 10 );
+
+                    setMessage(&USER_INTERFACE_STATE);
+                    break;
+
+                default:
+                    userInterfaceState = UI_STATE_NORMAL;
+                } // switch
+            } // SET
+        } // power on
+    } // rpm is zero
 
 #ifdef IGNORE_ALL_KEYS_WHEN_RUNNING
     if( currentRpm == 0 )
@@ -175,17 +309,42 @@ void UserInterface :: loop( void )
 #endif // IGNORE_ALL_KEYS_WHEN_RUNNING
 
         // these should only work when the power is on
-        if( this->core->isPowerOn() ) {
+        if( this->core->isPowerOn() )
+        {
             // these keys can be operated when the machine is running
-            if( keys.bit.UP )
+            switch (userInterfaceState)
             {
-                core->setFeed(feedTable->next());
-            }
-            if( keys.bit.DOWN )
-            {
-                core->setFeed(feedTable->previous());
-            }
-        }
+            case UI_STATE_NORMAL:
+
+                if( keys.bit.UP )
+                {
+                    core->setFeed(feedTable->next());
+                }
+                if( keys.bit.DOWN )
+                {
+                    core->setFeed(feedTable->previous());
+                }
+                break;
+
+            case UI_STATE_ADJ_BRT:
+
+                if( keys.bit.UP )
+                {
+                    controlPanel->increaseBrightness();
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
+                    setMessage(&USER_INTERFACE_STATE);
+                }
+
+                if( keys.bit.DOWN )
+                {
+                    controlPanel->decreaseBrightness();
+                    USER_INTERFACE_STATE.message[7] = digitToSevenSegmentPattern(controlPanel->getBrightness());
+                    setMessage(&USER_INTERFACE_STATE);
+                }
+
+                break;
+            } // switch
+        } // power is on
 
 #ifdef IGNORE_ALL_KEYS_WHEN_RUNNING
     }

--- a/els-f280049c/UserInterface.h
+++ b/els-f280049c/UserInterface.h
@@ -37,6 +37,7 @@
 #define UI_STATE_uSTPS 3
 #define UI_STATE_STEPPER_RES 4
 #define UI_STATE_ENCODER_RES 5
+#define UI_STATE_CANCEL 6
 
 typedef struct MESSAGE
 {

--- a/els-f280049c/UserInterface.h
+++ b/els-f280049c/UserInterface.h
@@ -31,6 +31,13 @@
 #include "Core.h"
 #include "Tables.h"
 
+#define UI_STATE_NORMAL 0
+#define UI_STATE_ADJ_BRT 1
+#define UI_STATE_LEADSCREW 2
+#define UI_STATE_uSTPS 3
+#define UI_STATE_STEPPER_RES 4
+#define UI_STATE_ENCODER_RES 5
+
 typedef struct MESSAGE
 {
     Uint16 message[8];
@@ -61,10 +68,14 @@ private:
     void setMessage(const MESSAGE *message);
     void overrideMessage( void );
 
+    Uint16 userInterfaceState;
+
 public:
     UserInterface(ControlPanel *controlPanel, Core *core, FeedTableFactory *feedTableFactory);
 
     void loop( void );
+
+    Uint16 static digitToSevenSegmentPattern(Uint16 x);
 };
 
 #endif // __USERINTERFACE_H

--- a/els-f280049c/main.cpp
+++ b/els-f280049c/main.cpp
@@ -139,6 +139,9 @@ void main(void)
         // mark beginning of loop for debugging
         debug.begin2();
 
+        // service heartbeat
+        debug.heartbeat();
+
         // service the user interface
         userInterface.loop();
 


### PR DESCRIPTION
SET button cycles through display of brightness, leadscrew pitch, stepper microsteps, stepper resolution, encoder resolution, and back to normal operation.
Any display will timeout in a couple seconds if the cycle isn't completed.
When displaying brightness, + and - buttons cycle brightness through five levels.
Add lower case letters to seven-segment patterns.